### PR TITLE
refactor: make `Text` immutable in `normalize`

### DIFF
--- a/src/change.rs
+++ b/src/change.rs
@@ -173,27 +173,13 @@ impl GridIndex {
     /// If the row value of the [`GridIndex`] is same as the number of rows, this will insert a
     /// line break.
     pub fn normalize(&mut self, text: &mut Text) -> Result<()> {
-        let br_indexes = &mut text.br_indexes;
-        let mut row_count = br_indexes.row_count();
-        if self.row == row_count.get() {
-            br_indexes.insert_index(self.row, br_indexes.last_row_start());
+        if self.row == text.br_indexes.row_count().get() {
+            let last = text.br_indexes.last_row_start();
+            text.br_indexes.insert_index(self.row, last);
             text.text.push('\n');
-            row_count = row_count.saturating_add(1);
         }
 
-        let row_start = br_indexes
-            .row_start(self.row)
-            .ok_or(Error::oob_row(row_count, self.row))?;
-        let pure_line = if !br_indexes.is_last_row(self.row) && row_count.get() > 1 {
-            let row_end = br_indexes
-                .row_start(self.row + 1)
-                .ok_or(Error::oob_row(row_count, self.row))?;
-            let base_line = &text.text[row_start..row_end];
-            trim_eol_from_end(base_line)
-        } else {
-            &text.text[row_start..]
-        };
-
+        let pure_line = resolve_pure_line(text, self.row)?;
         self.col = (text.encoding[0])(pure_line, self.col)?;
 
         Ok(())
@@ -203,25 +189,10 @@ impl GridIndex {
     ///
     /// Unlike [`GridIndex::normalize`], this does not mutate the [`Text`].
     pub fn normalize_2(&mut self, text: &Text) -> Result<()> {
-        let br_indexes = &text.br_indexes;
-        let row_count = br_indexes.row_count();
-
-        let pure_line = match self.row == row_count.get() {
-            true => "\n",
-            false => {
-                let row_start = br_indexes
-                    .row_start(self.row)
-                    .ok_or(Error::oob_row(row_count, self.row))?;
-                if !br_indexes.is_last_row(self.row) && row_count.get() > 1 {
-                    let row_end = br_indexes
-                        .row_start(self.row + 1)
-                        .ok_or(Error::oob_row(row_count, self.row))?;
-                    let base_line = &text.text[row_start..row_end];
-                    trim_eol_from_end(base_line)
-                } else {
-                    &text.text[row_start..]
-                }
-            }
+        let pure_line = if self.row == text.br_indexes.row_count().get() {
+            "\n"
+        } else {
+            resolve_pure_line(text, self.row)?
         };
 
         self.col = (text.encoding[0])(pure_line, self.col)?;
@@ -231,21 +202,7 @@ impl GridIndex {
 
     /// Transform the positions to the [`Text`]'s expected encoding, from UTF-8 positions.
     pub fn denormalize(&mut self, text: &Text) -> Result<()> {
-        let br_indexes = &text.br_indexes;
-        let row_count = br_indexes.row_count();
-        let row_start = br_indexes
-            .row_start(self.row)
-            .ok_or(Error::oob_row(row_count, self.row))?;
-        let pure_line = if !br_indexes.is_last_row(self.row) && row_count.get() > 1 {
-            let row_end = br_indexes
-                .row_start(self.row + 1)
-                .ok_or(Error::oob_row(row_count, self.row))?;
-            let base_line = &text.text[row_start..row_end];
-            trim_eol_from_end(base_line)
-        } else {
-            &text.text[row_start..]
-        };
-
+        let pure_line = resolve_pure_line(text, self.row)?;
         self.col = (text.encoding[1])(pure_line, self.col)?;
 
         Ok(())
@@ -257,5 +214,22 @@ pub(crate) fn correct_positions(start: &mut GridIndex, end: &mut GridIndex) {
         start.col = start.col.saturating_add(1);
         end.col += 1;
         std::mem::swap(start, end);
+    }
+}
+
+/// Resolve the line content for the given row, trimming EOL for non-last rows.
+pub(crate) fn resolve_pure_line<'a>(text: &'a Text, row: usize) -> Result<&'a str> {
+    let br_indexes = &text.br_indexes;
+    let row_count = br_indexes.row_count();
+    let row_start = br_indexes
+        .row_start(row)
+        .ok_or(Error::oob_row(row_count, row))?;
+    if !br_indexes.is_last_row(row) && row_count.get() > 1 {
+        let row_end = br_indexes
+            .row_start(row + 1)
+            .ok_or(Error::oob_row(row_count, row))?;
+        Ok(trim_eol_from_end(&text.text[row_start..row_end]))
+    } else {
+        Ok(&text.text[row_start..])
     }
 }

--- a/src/change.rs
+++ b/src/change.rs
@@ -170,19 +170,18 @@ mod lspt {
 impl GridIndex {
     /// Transform the positions from the [`Text`]'s expected encoding, to UTF-8 positions.
     ///
-    /// If the row value of the [`GridIndex`] is same as the number of rows, this will insert a
-    /// line break.
-    pub fn normalize(&mut self, text: &mut Text) -> Result<()> {
+    /// Returns `Ok(None)` when normalization succeeded normally.
+    /// Returns `Ok(Some("\n"))` when the row is at `row_count`, signaling a missing trailing
+    /// newline. The caller can then decide to append it, ignore it, or error.
+    pub fn normalize<'a>(&mut self, text: &'a Text) -> Result<Option<&'a str>> {
         if self.row == text.br_indexes.row_count().get() {
-            let last = text.br_indexes.last_row_start();
-            text.br_indexes.insert_index(self.row, last);
-            text.text.push('\n');
+            return Ok(Some("\n"));
         }
 
         let pure_line = resolve_pure_line(text, self.row)?;
         self.col = (text.encoding[0])(pure_line, self.col)?;
 
-        Ok(())
+        Ok(None)
     }
 
     /// Transform the positions to the [`Text`]'s expected encoding, from UTF-8 positions.

--- a/src/change.rs
+++ b/src/change.rs
@@ -185,21 +185,6 @@ impl GridIndex {
         Ok(())
     }
 
-    /// Transform the positions from the [`Text`]'s expected encoding, to UTF-8 positions.
-    ///
-    /// Unlike [`GridIndex::normalize`], this does not mutate the [`Text`].
-    pub fn normalize_2(&mut self, text: &Text) -> Result<()> {
-        let pure_line = if self.row == text.br_indexes.row_count().get() {
-            "\n"
-        } else {
-            resolve_pure_line(text, self.row)?
-        };
-
-        self.col = (text.encoding[0])(pure_line, self.col)?;
-
-        Ok(())
-    }
-
     /// Transform the positions to the [`Text`]'s expected encoding, from UTF-8 positions.
     pub fn denormalize(&mut self, text: &Text) -> Result<()> {
         let pure_line = resolve_pure_line(text, self.row)?;

--- a/src/change.rs
+++ b/src/change.rs
@@ -199,6 +199,36 @@ impl GridIndex {
         Ok(())
     }
 
+    /// Transform the positions from the [`Text`]'s expected encoding, to UTF-8 positions.
+    ///
+    /// Unlike [`GridIndex::normalize`], this does not mutate the [`Text`].
+    pub fn normalize_2(&mut self, text: &Text) -> Result<()> {
+        let br_indexes = &text.br_indexes;
+        let row_count = br_indexes.row_count();
+
+        let pure_line = match self.row == row_count.get() {
+            true => "\n",
+            false => {
+                let row_start = br_indexes
+                    .row_start(self.row)
+                    .ok_or(Error::oob_row(row_count, self.row))?;
+                if !br_indexes.is_last_row(self.row) && row_count.get() > 1 {
+                    let row_end = br_indexes
+                        .row_start(self.row + 1)
+                        .ok_or(Error::oob_row(row_count, self.row))?;
+                    let base_line = &text.text[row_start..row_end];
+                    trim_eol_from_end(base_line)
+                } else {
+                    &text.text[row_start..]
+                }
+            }
+        };
+
+        self.col = (text.encoding[0])(pure_line, self.col)?;
+
+        Ok(())
+    }
+
     /// Transform the positions to the [`Text`]'s expected encoding, from UTF-8 positions.
     pub fn denormalize(&mut self, text: &Text) -> Result<()> {
         let br_indexes = &text.br_indexes;

--- a/src/core/text.rs
+++ b/src/core/text.rs
@@ -153,8 +153,14 @@ impl Text {
         updateable: &mut U,
     ) -> Result<()> {
         self.update_prep();
-        start.normalize(self)?;
-        end.normalize(self)?;
+        if start.normalize(self)?.is_some() {
+            self.push_trailing_newline(&start);
+            start.normalize(self)?;
+        }
+        if end.normalize(self)?.is_some() {
+            self.push_trailing_newline(&end);
+            end.normalize(self)?;
+        }
         correct_positions(&mut start, &mut end);
         let max_row = self.br_indexes.row_count();
         let row_start_index = self
@@ -200,7 +206,10 @@ impl Text {
         updateable: &mut U,
     ) -> Result<()> {
         self.update_prep();
-        at.normalize(self)?;
+        if at.normalize(self)?.is_some() {
+            self.push_trailing_newline(&at);
+            at.normalize(self)?;
+        }
         let row_count = self.br_indexes.row_count();
         let row_end_index = self
             .nth_row(at.row)
@@ -250,8 +259,14 @@ impl Text {
         updateable: &mut U,
     ) -> Result<()> {
         self.update_prep();
-        start.normalize(self)?;
-        end.normalize(self)?;
+        if start.normalize(self)?.is_some() {
+            self.push_trailing_newline(&start);
+            start.normalize(self)?;
+        }
+        if end.normalize(self)?.is_some() {
+            self.push_trailing_newline(&end);
+            end.normalize(self)?;
+        }
         correct_positions(&mut start, &mut end);
         let row_count = self.br_indexes.row_count();
         let row_start_index = self
@@ -417,6 +432,19 @@ impl Text {
 
     fn update_prep(&mut self) {
         self.old_br_indexes.clone_from(&self.br_indexes);
+    }
+
+    /// Append a synthetic trailing newline so that `grid.row` (which points one past the last
+    /// existing row) becomes addressable.
+    ///
+    /// Called by `delete`/`insert`/`replace` when [`GridIndex::normalize`] returns `Some(_)`,
+    /// signaling that the requested row is `row_count` (i.e., the line break for the previous
+    /// row is missing). The caller is expected to re-run `normalize` afterwards to encode the
+    /// column against the now-existing empty line.
+    fn push_trailing_newline(&mut self, grid: &GridIndex) {
+        let last = self.br_indexes.last_row_start();
+        self.br_indexes.insert_index(grid.row, last);
+        self.text.push('\n');
     }
 }
 
@@ -1149,14 +1177,16 @@ mod tests {
             assert_eq!(t.br_indexes, [0, 17]);
 
             // Second call - this previously panicked due to missing update_prep()
-            t.replace_full(Cow::Borrowed("Second replacement\nAnother line\nThird"), &mut ())
-                .unwrap();
+            t.replace_full(
+                Cow::Borrowed("Second replacement\nAnother line\nThird"),
+                &mut (),
+            )
+            .unwrap();
             assert_eq!(t.text, "Second replacement\nAnother line\nThird");
             assert_eq!(t.br_indexes, [0, 18, 31]);
 
             // Third call to ensure stability
-            t.replace_full(Cow::Borrowed("Final"), &mut ())
-                .unwrap();
+            t.replace_full(Cow::Borrowed("Final"), &mut ()).unwrap();
             assert_eq!(t.text, "Final");
             assert_eq!(t.br_indexes, [0]);
         }


### PR DESCRIPTION
Related to #6

Hello,

I’ve noticed that `normalize` is used in several places in the [text](https://github.com/airblast-dev/texter/blob/2f4927d33682596e5d84d6497642d73ec2ed4eb3/src/core/text.rs#L156) module, so I introduced a temporary _normalize_2_ function.

When checking `if self.row == row_count.get()`, it seems to me that `normalize` is just passing `\n` to the encoding function ?

Also, `normalize` and `denormalize` share the same logic for creating the pure_line variable, so I extracted that logic into a helper function.